### PR TITLE
fix: use abbreviated date format for DB build date in Settings

### DIFF
--- a/LicensePlateGlossary/SettingsView.swift
+++ b/LicensePlateGlossary/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
                     if let date = dbBuildDate {
                         KeyValueRow(
                             key: String(localized: "Last updated at"),
-                            value: date.formatted(date: .long, time: .omitted),
+                            value: date.formatted(date: .abbreviated, time: .omitted),
                             systemImage: "calendar"
                         )
                     }


### PR DESCRIPTION
## Summary
- Changes `.long` → `.abbreviated` date format for the database build date shown in Settings
- Result: "April 17, 2026" → "Apr 17, 2026"

🤖 Generated with [Claude Code](https://claude.com/claude-code)